### PR TITLE
MAINT: adhere to new schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+
+- New dependency graph request schema in use.
+
 0.6.0 (26Apr23)
 ---------------
 

--- a/dtool_lookup_api/core/LookupClient.py
+++ b/dtool_lookup_api/core/LookupClient.py
@@ -355,7 +355,7 @@ class TokenBasedLookupClient:
                 logger = logging.getLogger(__name__)
                 logger.warning("Server returned no pagination information. Server version outdated.")
         else:  # TODO: validity check on dependency key list
-            dependency_graph = await self._post(f'/graph/lookup/{uuid}', dependency_keys)
+            dependency_graph = await self._post(f'/graph/lookup/{uuid}', {"dependency_keys": dependency_keys})
 
         return dependency_graph
 


### PR DESCRIPTION
The refactored graph plugin (https://github.com/livMatS/dtool-lookup-server-dependency-graph-plugin) requires a modifier request scheme here, see https://github.com/livMatS/dtool-lookup-server-dependency-graph-plugin/blob/4d85662bc08d083f439d708622330379cc8fee17/dtool_lookup_server_dependency_graph_plugin/schemas.py#LL8C6-L8C6