### PR TITLE
MAINT: declare requires-python >= 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
     {name = "Johannes L. Hörmann", email = "johannes.laurin@gmail.com"},
 ]
 dynamic = ["version"]
+requires-python = ">=3.8"
 dependencies = [
         "asgiref",
         "aiohttp",


### PR DESCRIPTION
## Summary
- Add `requires-python = ">=3.8"` to `pyproject.toml` to formally document the minimum supported Python version